### PR TITLE
github workflow setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit=env/**,src/tests/**

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,27 @@
+name: CodeCov
+on: push
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@master
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install coverage
+        pip install pytest
+        pip install pytest-cov
+    - name: Test with pytest
+        pytest src/tests/* --cov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        flags: pytest
+        fail_ci_if_error: true

--- a/src/enum_extend/__init__.py
+++ b/src/enum_extend/__init__.py
@@ -19,7 +19,7 @@ class EnumComparable(Enum):
     '''
     # Original: https://stackoverflow.com/questions/39268052/how-to-compare-enums-in-python
 
-    def __str_to_enum_comparable(self, enum_str: str) -> 'EnumComparable':
+    def __str_to_enum_comparable__(self, enum_str: str) -> 'EnumComparable':
         str_lst = enum_str.split('.')
         for str_chars in str_lst:
             # try_str will contain all alpha numeric chars containd in str_chars
@@ -40,7 +40,7 @@ class EnumComparable(Enum):
             return self.value > other
         if isinstance(other, str):
             try:
-                obj = self.__str_to_enum_comparable(other)
+                obj = self.__str_to_enum_comparable__(other)
                 return self.value > obj.value
             except ValueError as ex:
                 raise ex
@@ -55,7 +55,7 @@ class EnumComparable(Enum):
             return self.value < other
         if isinstance(other, str):
             try:
-                obj = self.__str_to_enum_comparable(other)
+                obj = self.__str_to_enum_comparable__(other)
                 return self.value < obj.value
             except ValueError as ex:
                 raise ex
@@ -72,7 +72,7 @@ class EnumComparable(Enum):
             try:
                 if self.name == other:
                     return True
-                obj = self.__str_to_enum_comparable(other)
+                obj = self.__str_to_enum_comparable__(other)
                 return self.value >= obj.value
             except ValueError as ex:
                 raise ex
@@ -89,7 +89,7 @@ class EnumComparable(Enum):
             try:
                 if self.name == other:
                     return True
-                obj = self.__str_to_enum_comparable(other)
+                obj = self.__str_to_enum_comparable__(other)
                 return self.value <= obj.value
             except ValueError as ex:
                 raise ex
@@ -106,7 +106,7 @@ class EnumComparable(Enum):
             return self.value == other
         if isinstance(other, str):
             try:
-                obj = self.__str_to_enum_comparable(other)
+                obj = self.__str_to_enum_comparable__(other)
                 return self.value == obj.value
             except ValueError:
                 return False
@@ -139,7 +139,7 @@ class EnumComparable(Enum):
                 raise ValueError(msg) from ex
         if isinstance(other, str):
             try:
-                other_enum = self.__str_to_enum_comparable(other)
+                other_enum = self.__str_to_enum_comparable__(other)
                 new_val = self.value + other_enum.value
                 obj = self.__class__(new_val)
                 return obj
@@ -186,7 +186,7 @@ class EnumComparable(Enum):
                 raise ValueError(msg) from ex
         if isinstance(other, str):
             try:
-                other_enum = self.__str_to_enum_comparable(other)
+                other_enum = self.__str_to_enum_comparable__(other)
                 new_val = self.value - other_enum.value
                 obj = self.__class__(new_val)
                 return obj


### PR DESCRIPTION
initial workflow setup.

Also include rename of method **__str_to_enum_comparable** to **__str_to_enum_comparable__** as pytetst was raising warning.