### PR TITLE
readthedocs python 3.9 to python 3.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ sphinx:
 
 formats: []
 python:
-   version: "3.9"
+   version: "3.8"
 
 conda:
   environment: environment.yml


### PR DESCRIPTION
readthe docs only supports currently up to python 3.8